### PR TITLE
Automatic update of NUnit3TestAdapter to 3.13.0

### DIFF
--- a/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
+++ b/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit3TestAdapter` to `3.13.0` from `3.11.0`
`NUnit3TestAdapter 3.13.0` was published at `2019-02-21T11:35:37Z`, 4 months ago

1 project update:
Updated `NuKeeper.Git.Tests\NuKeeper.Git.Tests.csproj` to `NUnit3TestAdapter` `3.13.0` from `3.11.0`

[NUnit3TestAdapter 3.13.0 on NuGet.org](https://www.nuget.org/packages/NUnit3TestAdapter/3.13.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
